### PR TITLE
Changing path to /public for now. Will be dynamic later

### DIFF
--- a/api.go
+++ b/api.go
@@ -129,7 +129,7 @@ func Build(buildDir, projectName, remotePath string) string {
 			logging.LogToFile("Container built...transfering built files...")
 			GrabBuiltStaticFiles(buildTag, projectName, buildDir)
 			if os.Getenv("ENV") != "test" {
-				rsyncProject(buildDir+"/dist/*", remotePath)
+				rsyncProject(buildDir+"/public/*", remotePath)
 			}
 			return "success"
 		}


### PR DESCRIPTION
This is the new convention we are using internally. Eventually, we will allow users to specify this somehow.
